### PR TITLE
fix: update action for handle new name

### DIFF
--- a/.github/workflows/test-sdk-pr.yaml
+++ b/.github/workflows/test-sdk-pr.yaml
@@ -48,7 +48,12 @@ jobs:
           # Get the package name and version
           PACKAGE_NAME=$(node -p "require('./package.json').name")
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
-          TARBALL_NAME="${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz"
+
+          # npm pack creates tarballs with the format: scope-package-name-version.tgz
+          # For @censys/platform-sdk, it becomes censys-platform-sdk-0.5.1.tgz
+          # Remove the @ symbol and replace / with -
+          TARBALL_NAME="${PACKAGE_NAME#@}-${PACKAGE_VERSION}.tgz"
+          TARBALL_NAME="${TARBALL_NAME//\//-}"
 
           # Set output for use in other steps
           echo "tarball_name=$TARBALL_NAME" >> $GITHUB_OUTPUT

--- a/tests/sdk.test.ts
+++ b/tests/sdk.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { SDK } from "censys-sdk-typescript";
+import { SDK } from "@censys/platform-sdk";
 import {
   V3CollectionsCrudCreateRequest,
   V3CollectionsCrudDeleteRequest,
@@ -18,7 +18,7 @@ import {
   V3GlobaldataSearchAggregateRequest,
   V3GlobaldataSearchQueryRequest,
   V3ThreathuntingValueCountsRequest,
-} from "censys-sdk-typescript/models/operations";
+} from "@censys/platform-sdk/models/operations";
 
 describe("Censys SDK", () => {
   let sdk: SDK;


### PR DESCRIPTION
# Changes

Updates the testing GitHub Action to handle the updated SDK name

## Why:

The SDK's name is now `@censys/typescript-sdk` but the pipeline wasn't a fan of the `@` or the `/`. 
This removes those characters from the package name during the testing pipeline

## How to test

- Do the action(s) kick off?
- Do the tests pass?
- Does the action finish